### PR TITLE
Switch to Jib for Docker builds and streamline workflows

### DIFF
--- a/.github/workflows/business-partners-service-dev.yml
+++ b/.github/workflows/business-partners-service-dev.yml
@@ -11,6 +11,10 @@ concurrency:
   group: business-partners-service-deploy-dev-one21
   cancel-in-progress: true
 
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/dev-business-partners-service
+  IMAGE_TAG: ${{ github.run_number }}
+
 jobs:
   build:
     name: Build JAR
@@ -30,9 +34,13 @@ jobs:
         working-directory: commons/generic-data
         run: mvn -B clean install
 
-      - name: Build service
-        working-directory: apps/business-partners-service
-        run: mvn -B clean package -DskipTests
+      - name: Build service (skip tests & checks)
+        run: |
+          mvn -Dmaven.test.skip \
+              -Djacoco.skip \
+              -Ddependency-check.skip=true \
+              -f apps/business-partners-service \
+              compile package
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -41,7 +49,7 @@ jobs:
           path: apps/business-partners-service/target/*.jar
 
   docker-build:
-    name: Build & Push Docker Image
+    name: Build & Push Docker Image with Jib
     runs-on: ubuntu-latest
     needs: build
     environment: DEV-ONE21
@@ -49,20 +57,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
       - name: Log in to DockerHub
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
-      - name: Build Docker image
+      - name: Build Docker image with Jib
         run: |
-          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/dev-business-partners-service
-          IMAGE_TAG=${{ github.run_number }}
-          docker build -t $IMAGE_NAME:$IMAGE_TAG ./apps/business-partners-service
+          mvn -Dmaven.test.skip \
+              -Djacoco.skip \
+              -Ddependency-check.skip=true \
+              -f apps/business-partners-service \
+              compile jib:dockerBuild \
+              -Dimage=${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
       - name: Push Docker image
-        run: |
-          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/dev-business-partners-service
-          IMAGE_TAG=${{ github.run_number }}
-          docker push $IMAGE_NAME:$IMAGE_TAG
+        run: docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
   deploy:
     name: Deploy to Kubernetes
@@ -95,6 +110,6 @@ jobs:
             ./apps/business-partners-service/charts/ \
             --namespace ${{ vars.NAMESPACE }} \
             --create-namespace \
-            --set image.repository=${{ secrets.DOCKERHUB_USERNAME }}/dev-business-partners-service \
-            --set image.tag=${{ github.run_number }} \
+            --set image.repository=${{ env.IMAGE_NAME }} \
+            --set image.tag=${{ env.IMAGE_TAG }} \
             --wait --atomic --timeout 5m

--- a/.github/workflows/business-partners-service.yml
+++ b/.github/workflows/business-partners-service.yml
@@ -11,6 +11,10 @@ concurrency:
   group: business-partners-service-deploy-one21
   cancel-in-progress: true
 
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/business-partners-service
+  IMAGE_TAG: ${{ github.run_number }}
+
 jobs:
   build:
     name: Build JAR
@@ -30,9 +34,13 @@ jobs:
         working-directory: commons/generic-data
         run: mvn -B clean install
 
-      - name: Build service
-        working-directory: apps/business-partners-service
-        run: mvn -B clean package -DskipTests
+      - name: Build service (skip tests & checks)
+        run: |
+          mvn -Dmaven.test.skip \
+              -Djacoco.skip \
+              -Ddependency-check.skip=true \
+              -f apps/business-partners-service \
+              compile package
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -41,7 +49,7 @@ jobs:
           path: apps/business-partners-service/target/*.jar
 
   docker-build:
-    name: Build & Push Docker Image
+    name: Build & Push Docker Image with Jib
     runs-on: ubuntu-latest
     needs: build
     environment: ONE21
@@ -49,20 +57,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
       - name: Log in to DockerHub
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
-      - name: Build Docker image
+      - name: Build Docker image with Jib
         run: |
-          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/business-partners-service
-          IMAGE_TAG=${{ github.run_number }}
-          docker build -t $IMAGE_NAME:$IMAGE_TAG ./apps/business-partners-service
+          mvn -Dmaven.test.skip \
+              -Djacoco.skip \
+              -Ddependency-check.skip=true \
+              -f apps/business-partners-service \
+              compile jib:dockerBuild \
+              -Dimage=${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
       - name: Push Docker image
-        run: |
-          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/business-partners-service
-          IMAGE_TAG=${{ github.run_number }}
-          docker push $IMAGE_NAME:$IMAGE_TAG
+        run: docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
   deploy:
     name: Deploy to Kubernetes
@@ -95,6 +110,6 @@ jobs:
             ./apps/business-partners-service/charts/ \
             --namespace ${{ vars.NAMESPACE }} \
             --create-namespace \
-            --set image.repository=${{ secrets.DOCKERHUB_USERNAME }}/business-partners-service \
-            --set image.tag=${{ github.run_number }} \
+            --set image.repository=${{ env.IMAGE_NAME }} \
+            --set image.tag=${{ env.IMAGE_TAG }} \
             --wait --atomic --timeout 5m


### PR DESCRIPTION
Replaces manual Docker build and push commands with Jib for automated Docker image creation and deployment. Introduces environment variables for image naming and tagging, reducing duplication and improving configurability.

Upgrades Java version to 21 for Docker build jobs and optimizes Maven build steps by skipping tests and checks to improve build efficiency.

Enhances Helm deployment by using centralized environment variables for image repository and tag configuration.