### PR TITLE
Remove trailing slashes from REST controller request mappings

### DIFF
--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/AddressController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/AddressController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("addresses/")
+@RequestMapping("addresses")
 public class AddressController extends GenericController<AddressDto, Address, Integer> {
 
     public AddressController(AddressService addressService) {

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/BankAccountController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/BankAccountController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @RestController
-@RequestMapping("bank-accounts/")
+@RequestMapping("bank-accounts")
 class BankAccountController extends GenericController<BankAccountDto, BankAccount, Integer> {
 
     public BankAccountController(BankAccountService bankAccountService) {

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/CategoryController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/CategoryController.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RestController("categories/")
+@RestController("categories")
 public class CategoryController extends GenericController<CategoryDto, Category, Integer> {
     private final CategoryService categoryService;
 

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/ContactController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/ContactController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
-@RequestMapping("contacts/")
+@RequestMapping("contacts")
 public class ContactController extends GenericController<ContactDto, Contact, Integer> {
 
     public ContactController(ContactService contactService) {

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/CountryController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/CountryController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
-@RequestMapping("countries/")
+@RequestMapping("countries")
 public class CountryController extends GenericController<CountryDto, Country, Integer> {
 
     private CountryService countryService;

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/PartnerController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/PartnerController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("partners/")
+@RequestMapping("partners")
 public class PartnerController extends GenericController<PartnerDto, Partner, Integer> {
 
     public PartnerController(PartnerService partnerService) {

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/StateController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/StateController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("states/")
+@RequestMapping("states")
 public class StateController extends GenericController<StateDto, State, Integer> {
 
     public StateController(StateService stateService) {

--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/TypeController.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/controllers/TypeController.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@RestController("types/")
+@RestController("types")
 public class TypeController<TypeDto, Type, Integer> {
 
     private final TypeService typeService;


### PR DESCRIPTION
Standardizes request mappings across all REST controllers by removing trailing slashes from the @RequestMapping annotations.

This improves consistency in endpoint definitions and aligns with best practices for URL design.