### PR TITLE
Excludes Swagger and API docs paths from authentication

### DIFF
--- a/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/security/keycloak/RedisAuthFilter.java
+++ b/apps/business-partners-service/src/main/java/gt/edu/umg/business/partners/service/security/keycloak/RedisAuthFilter.java
@@ -17,6 +17,11 @@ public class RedisAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+        String path = request.getRequestURI();
+        if (path.startsWith("/swagger-ui") || path.startsWith("/v3/api-docs")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);


### PR DESCRIPTION
Skips authentication for requests to Swagger UI and API documentation endpoints to allow unrestricted access for documentation purposes.

Ensures these resources are accessible without interfering with the authorization filter logic.